### PR TITLE
API URL 에러 수정

### DIFF
--- a/client/src/libs/axios.ts
+++ b/client/src/libs/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { storage } from '../utils/storage';
 import { ACCESS_TOKEN } from '../commons/constants';
 
-const REACT_APP_SERVER_URL = document.URL;
+const REACT_APP_SERVER_URL = `//${window.location.host}`;
 const accessToken = storage.get(ACCESS_TOKEN);
 
 export const Axios = axios.create({


### PR DESCRIPTION
`example.com/////` 이렇게 들어오면, express가 라우팅을 제대로 처리 못해, 화면이 제대로 표시되지 않는 버그 발견함.

window.location.host를 이용해서 해결
결과 예시: `${HOST}:${PORT}`